### PR TITLE
Added support for compiler options/ignore compiler warnings

### DIFF
--- a/src/main/java/org/mdkt/compiler/InMemoryJavaCompiler.java
+++ b/src/main/java/org/mdkt/compiler/InMemoryJavaCompiler.java
@@ -30,6 +30,14 @@ public class InMemoryJavaCompiler {
 	}
 
 	/**
+	 * @return the class loader used internally by the compiler
+	 */
+	public ClassLoader getClassloader()
+	{
+		return classLoader;
+	}
+
+	/**
 	 * Options used by the compiler, e.g. '-Xlint:unchecked'.
 	 * @param options
 	 * @return

--- a/src/test/java/org/mdkt/compiler/InMemoryJavaCompilerTest.java
+++ b/src/test/java/org/mdkt/compiler/InMemoryJavaCompilerTest.java
@@ -1,5 +1,6 @@
 package org.mdkt.compiler;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -66,5 +67,28 @@ public class InMemoryJavaCompilerTest {
 		sourceCode.append("   public String hello() { return \"hello\"; }");
 		sourceCode.append("}");
 		InMemoryJavaCompiler.newInstance().compile("org.mdkt.HelloClass", sourceCode.toString());
+	}
+
+	@Test public void compile_FailOnWarnings() throws Exception{
+		thrown.expect(CompilationException.class);
+		StringBuffer sourceCode = new StringBuffer();
+
+		sourceCode.append("package org.mdkt;\n");
+		sourceCode.append("public class HelloClass {\n");
+		sourceCode.append("   public java.util.List<String> hello() { return new java.util.ArrayList(); }");
+		sourceCode.append("}");
+		InMemoryJavaCompiler.newInstance().compile("org.mdkt.HelloClass", sourceCode.toString());
+	}
+
+	@Test public void compile_CompileAndIgnoreWarnings() throws Exception{
+		StringBuffer sourceCode = new StringBuffer();
+
+		sourceCode.append("package org.mdkt;\n");
+		sourceCode.append("public class HelloClass {\n");
+		sourceCode.append("   public java.util.List<String> hello() { return new java.util.ArrayList(); }");
+		sourceCode.append("}");
+		Class<?> helloClass = InMemoryJavaCompiler.newInstance().useIgnoreWarnings().compile("org.mdkt.HelloClass", sourceCode.toString());
+		List<?> res = (List) helloClass.getMethod("hello").invoke(helloClass.newInstance());
+		Assert.assertEquals(0, res.size());
 	}
 }


### PR DESCRIPTION
Hi trung,

thx for including my pull req and maintaining InMemoryJavaCompiler. When porting my code to the new version i had some fails compiling some generated code due to compiler warnings, so I added support for compiler options and for ignoring compiler warnings.

Best regards,

turpid-monkey