### PR TITLE
Introduce a result interface to allow extraction of diagnostics

### DIFF
--- a/src/main/java/org/mdkt/compiler/CompilationResult.java
+++ b/src/main/java/org/mdkt/compiler/CompilationResult.java
@@ -1,0 +1,40 @@
+package org.mdkt.compiler;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+public interface CompilationResult {
+	/**
+	 * Return the compiled classes
+	 */
+	Map<String, Class<?>> classMap() throws ClassNotFoundException;
+
+	/**
+	 * Determine if the compilation did succeed
+	 */
+	boolean compilationSucceeded();
+
+	/**
+	 * Determine if any warnings are present
+	 */
+	boolean hasWarnings();
+
+	/**
+	 * Determine if any errors are present
+	 */
+	boolean hasErrors();
+
+	/**
+	 * Return the diagnostics produced by the compiler
+	 */
+	List<Diagnostic<? extends JavaFileObject>> getDiagnostics();
+
+	/**
+	 * Throw an exception if the compilation did not succeed
+	 */
+	CompilationResult checkNoErrors();
+
+}


### PR DESCRIPTION
I need access to the individual diagnostics messages. Unfortunately, the only implemented behaviour was to throw an exception when on compile errors/warnings. What do you think?